### PR TITLE
Feature/simulator interaction topology

### DIFF
--- a/simulator-project-simulator/tests/conftest.py
+++ b/simulator-project-simulator/tests/conftest.py
@@ -1,0 +1,24 @@
+import pytest
+
+from runner.soa import to_soa
+from runner.state import AgentState
+import uuid
+
+@pytest.fixture
+def sample_soa():
+    agents = [
+        AgentState(agent_id=str(uuid.uuid4()), agent_type_name='person', state={'energy': i})
+        for i in range(10)
+    ]
+    return to_soa(agents)
+
+@pytest.fixture
+def mixed_type_soa():
+    agents = [
+        AgentState(agent_id=str(uuid.uuid4()), agent_type_name='predator', state={'energy': i})
+        for i in range(5)
+    ] + [
+        AgentState(agent_id=str(uuid.uuid4()), agent_type_name='prey', state={'energy': i})
+        for i in range(5)
+    ]
+    return to_soa(agents)

--- a/simulator-project-simulator/tests/conftest.py
+++ b/simulator-project-simulator/tests/conftest.py
@@ -22,3 +22,7 @@ def mixed_type_soa():
         for i in range(5)
     ]
     return to_soa(agents)
+
+@pytest.fixture
+def sample_soa_single_agent():
+    return to_soa([AgentState(agent_id=str(uuid.uuid4()), agent_type_name='person', state={'energy': 1})])

--- a/simulator-project-simulator/tests/test_all_pairs.py
+++ b/simulator-project-simulator/tests/test_all_pairs.py
@@ -1,0 +1,93 @@
+import pytest
+import random
+
+from topology.all_pairs import AllPairsTopology
+
+def test_generate_all_pairs_invalid_agent_type(sample_soa):
+    config = {'topologies': {'sample_network': {'mode': 'all_pairs', 'agent_types': ['invalid_agent_type']}}}
+    with pytest.raises(ValueError):
+        AllPairsTopology.from_config(config['topologies']['sample_network'], sample_soa)
+
+def test_all_pairs_get_neighbours_success(sample_soa):
+    config = {'topologies': {'sample_network': {'mode': 'all_pairs', 'agent_types': ['person']}}}
+    pairs = AllPairsTopology.from_config(config['topologies']['sample_network'], sample_soa)
+
+    # Pick a real agent ID from the population
+    agent_ids = list(sample_soa['person']['__ids__'])
+    focal_agent_id = str(agent_ids[0])
+
+    neighbours = pairs.get_neighbours(focal_agent_id, sample_soa)
+
+    assert len(neighbours) == len(agent_ids) - 1  # N-1, self excluded
+
+def test_all_pairs_excludes_self_by_default(sample_soa):
+    config = {'topologies': {'sample_network': {'mode': 'all_pairs', 'agent_types': ['person']}}}
+    pairs = AllPairsTopology.from_config(config['topologies']['sample_network'], sample_soa)
+
+    # Pick a real agent ID from the population
+    agent_ids = list(sample_soa['person']['__ids__'])
+    target_agent_id = str(agent_ids[random.randint(0, len(agent_ids) - 1)])
+
+    neighbours = pairs.get_neighbours(target_agent_id, sample_soa)
+    assert target_agent_id not in neighbours
+
+    assert len(neighbours) == len(agent_ids) - 1  # N-1, self excluded
+
+def test_all_pairs_allows_self_interaction_when_enabled(sample_soa):
+    config = {'topologies': {'sample_network': {'mode': 'all_pairs', 'agent_types': ['person'], 'allow_self_interaction': True}}}
+    pairs = AllPairsTopology.from_config(config['topologies']['sample_network'], sample_soa)
+
+    # Pick a real agent ID from the population
+    agent_ids = list(sample_soa['person']['__ids__'])
+    target_agent_id = str(agent_ids[random.randint(0, len(agent_ids) - 1)])
+
+    neighbours = pairs.get_neighbours(target_agent_id, sample_soa)
+    assert target_agent_id in neighbours
+    assert len(neighbours) == len(agent_ids)
+
+def test_all_pairs_cross_type_interaction_success(mixed_type_soa):
+    config = {'topologies': {
+        'sample_network': {'mode': 'all_pairs', 'agent_types': ['predator', 'prey']}}}
+    pairs = AllPairsTopology.from_config(config['topologies']['sample_network'], mixed_type_soa)
+
+    # Pick a real agent ID from the population
+    agent_ids = list(mixed_type_soa['predator']['__ids__']) + list(mixed_type_soa['prey']['__ids__'])
+    target_agent_id = str(agent_ids[random.randint(0, len(agent_ids) - 1)])
+
+    neighbours = pairs.get_neighbours(target_agent_id, mixed_type_soa)
+    assert target_agent_id not in neighbours
+    assert len(neighbours) == len(agent_ids) - 1
+
+def test_all_pairs_filters_by_agent_types(mixed_type_soa):
+    config = {'topologies': {
+        'sample_network': {'mode': 'all_pairs', 'agent_types': ['predator']}}}
+    pairs = AllPairsTopology.from_config(config['topologies']['sample_network'], mixed_type_soa)
+
+    # Pick a real agent ID from the population
+    agent_ids = list(mixed_type_soa['predator']['__ids__'])
+    target_agent_id = str(agent_ids[random.randint(0, len(agent_ids) - 1)])
+
+    neighbours = pairs.get_neighbours(target_agent_id, mixed_type_soa)
+    assert target_agent_id not in neighbours
+    assert len(neighbours) == len(agent_ids) -1
+
+def test_all_pairs_from_config_success(sample_soa):
+    config = {'topologies': {
+        'sample_network': {'mode': 'all_pairs', 'agent_types': ['person']}}}
+    pairs = AllPairsTopology.from_config(config['topologies']['sample_network'], sample_soa)
+
+    assert pairs.allow_self_interaction == False
+    assert pairs.agent_types == ['person']
+
+def test_all_pairs_single_agent_returns_empty(sample_soa_single_agent):
+    config = {'topologies': {
+        'sample_network': {'mode': 'all_pairs', 'agent_types': ['person']}}}
+    pairs = AllPairsTopology.from_config(config['topologies']['sample_network'], sample_soa_single_agent)
+
+    # Pick a real agent ID from the population
+    agent_ids = list(sample_soa_single_agent['person']['__ids__'])
+    target_agent_id = str(agent_ids[0])
+
+    neighbours = pairs.get_neighbours(target_agent_id, sample_soa_single_agent)
+
+    assert len(neighbours) == 0

--- a/simulator-project-simulator/tests/test_graph_builder.py
+++ b/simulator-project-simulator/tests/test_graph_builder.py
@@ -1,0 +1,139 @@
+import pytest
+import networkx as nx
+import tempfile
+import os
+
+from topology.graph_builder import build_graph
+
+def test_build_graph_by_erdos_renyi_success(sample_soa):
+    config = {'mode': 'network', 'graph': {'type': 'erdos_renyi', 'n': 10, 'p': 0.5, 'seed': 1}}
+    generated_graph = build_graph(config['graph'], sample_soa)
+
+    agent_ids = set(str(id_) for id_ in sample_soa['person']['__ids__'])
+    assert set(generated_graph.nodes()) == agent_ids
+
+def test_build_graph_by_barabasi_albert_success(sample_soa):
+    config = {'mode': 'network', 'graph': {'type': 'barabasi_albert', 'n': 10, 'm': 2, 'seed': 1}}
+    generated_graph = build_graph(config['graph'], sample_soa)
+
+    agent_ids = set(str(id_) for id_ in sample_soa['person']['__ids__'])
+    assert set(generated_graph.nodes()) == agent_ids
+
+def test_build_graph_by_watts_strogatz_success(sample_soa):
+    config = {'mode': 'network', 'graph': {'type': 'watts_strogatz', 'n': 10, 'k': 3, 'p': 0.33, 'seed': 1}}
+    generated_graph = build_graph(config['graph'], sample_soa)
+
+    agent_ids = set(str(id_) for id_ in sample_soa['person']['__ids__'])
+    assert set(generated_graph.nodes()) == agent_ids
+
+def test_build_graph_by_algorithm_with_excess_n_throws_value_error(sample_soa):
+    config = {'mode': 'network', 'graph': {'type': 'erdos_renyi', 'n': 10000, 'p': 0.5, 'seed': 1}}
+    with pytest.raises(ValueError) as e:
+        build_graph(config['graph'], sample_soa)
+    assert e.match(f'n={config['graph']["n"]} does not match total agent')
+
+def test_build_graph_by_unknown_algorithm_throws_value_error(sample_soa):
+    config = {'mode': 'network', 'graph': {'type': 'unknown', 'n': 10, 'k': 3, 'p': 0.33, 'seed': 1}}
+    with pytest.raises(ValueError) as e:
+        build_graph(config['graph'], sample_soa)
+    assert "Unknown graph type" in str(e.value)
+
+def test_build_graph_by_graphml_file_success(sample_soa):
+    agent_ids = [str(id_) for id_ in sample_soa['person']['__ids__']]
+    graph = nx.Graph()
+    graph.add_nodes_from(agent_ids)
+    # Ensure every node has at least one edge before adding random extras
+    for i in range(len(agent_ids)):
+        graph.add_edge(agent_ids[i], agent_ids[(i + 1) % len(agent_ids)])
+
+    try:
+        with tempfile.NamedTemporaryFile(suffix='.graphml', delete=False) as f:
+            path = f.name
+        nx.write_graphml(graph, path)
+        config = {'mode': 'network', 'source': path}
+        generated_graph = build_graph(config, sample_soa)
+
+        assert set(generated_graph.nodes()) == set(graph.nodes())
+        assert set(map(frozenset, generated_graph.edges())) == set(map(frozenset, graph.edges()))
+    finally:
+        os.remove(path)
+
+
+def test_build_graph_by_gml_file_success(sample_soa):
+    agent_ids = [str(id_) for id_ in sample_soa['person']['__ids__']]
+    graph = nx.Graph()
+    graph.add_nodes_from(agent_ids)
+    # Ensure every node has at least one edge before adding random extras
+    for i in range(len(agent_ids)):
+        graph.add_edge(agent_ids[i], agent_ids[(i + 1) % len(agent_ids)])
+
+    try:
+        with tempfile.NamedTemporaryFile(suffix='.gml', delete=False) as f:
+            path = f.name
+        nx.write_gml(graph, path)
+        config = {'mode': 'network', 'source': path}
+        generated_graph = build_graph(config, sample_soa)
+
+        assert set(generated_graph.nodes()) == set(graph.nodes())
+        assert set(map(frozenset, generated_graph.edges())) == set(map(frozenset, graph.edges()))
+    finally:
+        os.remove(path)
+
+def test_build_graph_by_edgelist_file_success(sample_soa):
+    agent_ids = [str(id_) for id_ in sample_soa['person']['__ids__']]
+    graph = nx.Graph()
+    graph.add_nodes_from(agent_ids)
+    # Ensure every node has at least one edge before adding random extras
+    for i in range(len(agent_ids)):
+        graph.add_edge(agent_ids[i], agent_ids[(i + 1) % len(agent_ids)])
+
+    try:
+        with tempfile.NamedTemporaryFile(suffix='.edgelist', delete=False) as f:
+            path = f.name
+        nx.write_edgelist(graph, path)
+        config = {'mode': 'network', 'source': path}
+        generated_graph = build_graph(config, sample_soa)
+
+        assert set(generated_graph.nodes()) == set(graph.nodes())
+        assert set(map(frozenset, generated_graph.edges())) == set(map(frozenset, graph.edges()))
+    finally:
+        os.remove(path)
+
+def test_build_graph_by_adjlist_file_success(sample_soa):
+    agent_ids = [str(id_) for id_ in sample_soa['person']['__ids__']]
+    graph = nx.Graph()
+    graph.add_nodes_from(agent_ids)
+    # Ensure every node has at least one edge before adding random extras
+    for i in range(len(agent_ids)):
+        graph.add_edge(agent_ids[i], agent_ids[(i + 1) % len(agent_ids)])
+
+    try:
+        with tempfile.NamedTemporaryFile(suffix='.adjlist', delete=False) as f:
+            path = f.name
+        nx.write_adjlist(graph, path)
+        config = {'mode': 'network', 'source': path}
+        generated_graph = build_graph(config, sample_soa)
+
+        assert set(generated_graph.nodes()) == set(graph.nodes())
+        assert set(map(frozenset, generated_graph.edges())) == set(map(frozenset, graph.edges()))
+    finally:
+        os.remove(path)
+
+def test_build_graph_file_with_mismatched_node_ids_raises(sample_soa):
+    graph = nx.erdos_renyi_graph(n=10, p=0.5, seed=1)  # default integer node labels, not UUIDs
+
+    try:
+        with tempfile.NamedTemporaryFile(suffix='.graphml', delete=False) as f:
+            path = f.name
+        nx.write_graphml(graph, path)
+        config = {'source': path}
+        with pytest.raises(ValueError, match="do not match"):
+            build_graph(config, sample_soa)
+    finally:
+        os.remove(path)
+
+def test_build_graph_no_source_type_throws_value_error(sample_soa):
+    config = {'sample_network': {'mode': 'network', 'agent_types': 'person', 'graph': {'n': 10, 'p': 0.05, 'seed': 1}}}
+    with pytest.raises(ValueError) as e:
+        build_graph(config['sample_network']['graph'], sample_soa)
+    assert e.match("Graph config must contain either 'source' or 'type'.")

--- a/simulator-project-simulator/tests/test_network.py
+++ b/simulator-project-simulator/tests/test_network.py
@@ -1,0 +1,90 @@
+import pytest
+import random
+import networkx as nx
+
+from topology.network import NetworkTopology
+
+def test_network_from_config_generates_graph_success(sample_soa):
+    config = {'mode': 'network', 'agent_types': ['person'], 'graph': {'type': 'erdos_renyi', 'n': 10, 'p': 0.5, 'seed': 1}}
+    result = NetworkTopology.from_config(config, sample_soa)
+
+    assert isinstance(result, NetworkTopology)
+    assert result.agent_types == ['person']
+
+def test_network_from_config_missing_graph_section_raises(sample_soa):
+    config = {'mode': 'network', 'agent_types': ['person']}
+    with pytest.raises(ValueError) as e:
+        NetworkTopology.from_config(config, sample_soa)
+    assert "Network topology config must contain a 'graph' section." in str(e.value)
+
+def test_network_get_neighbours_returns_adjacent_nodes(sample_soa):
+    config = {'mode': 'network', 'agent_types': ['person'],
+              'graph': {'type': 'erdos_renyi', 'n': 10, 'p': 0.5, 'seed': 1}}
+    graph = NetworkTopology.from_config(config, sample_soa)
+
+    agent_ids = list(sample_soa['person']['__ids__'])
+    target_agent_id = str(agent_ids[random.randint(0, len(agent_ids) - 1)])
+
+    neighbours = graph.get_neighbours(target_agent_id, sample_soa)
+    expected = list(graph.graph.neighbors(target_agent_id))
+
+    assert set(neighbours) == set(expected)
+
+def test_network_get_neighbours_excludes_self_by_default(sample_soa):
+    config = {'mode': 'network', 'agent_types': ['person'],
+              'graph': {'type': 'erdos_renyi', 'n': 10, 'p': 0.5, 'seed': 1}}
+    generated_graph = NetworkTopology.from_config(config, sample_soa)
+
+    agent_ids = list(sample_soa['person']['__ids__'])
+    target_agent_id = str(agent_ids[random.randint(0, len(agent_ids) - 1)])
+
+    neighbours = generated_graph.get_neighbours(target_agent_id, sample_soa)
+
+    assert target_agent_id not in neighbours
+
+def test_network_get_neighbours_isolated_node_returns_empty(sample_soa):
+    agent_ids = [str(id_) for id_ in sample_soa['person']['__ids__']]
+    graph = nx.Graph()
+    graph.add_nodes_from(agent_ids)
+
+    topology = NetworkTopology(graph=graph)
+
+    target_agent_id = agent_ids[0]
+    neighbours = topology.get_neighbours(target_agent_id, sample_soa)
+
+    assert neighbours == []
+
+def test_network_get_neighbours_agent_not_in_graph_returns_empty(sample_soa):
+    agent_ids = [str(id_) for id_ in sample_soa['person']['__ids__']]
+    graph = nx.Graph()
+    graph.add_nodes_from(agent_ids)
+
+    target_agent_id = agent_ids[0]
+    graph.remove_node(target_agent_id)
+
+    topology = NetworkTopology(graph=graph)
+
+    neighbours = topology.get_neighbours(target_agent_id, sample_soa)
+
+    assert neighbours == []
+
+def test_network_filters_by_agent_types(mixed_type_soa):
+    config = {'mode': 'network', 'agent_types': ['predator'],
+              'graph': {'type': 'erdos_renyi', 'n': 10, 'p': 0.5, 'seed': 1}}
+    generated_graph = NetworkTopology.from_config(config, mixed_type_soa)
+
+    assert isinstance(generated_graph, NetworkTopology)
+    assert generated_graph.agent_types == ['predator']
+
+    predator_ids = list(mixed_type_soa['predator']['__ids__'])
+    target_agent_id = str(predator_ids[0])
+    neighbours = generated_graph.get_neighbours(target_agent_id, mixed_type_soa)
+    prey_ids = set(str(id_) for id_ in mixed_type_soa['prey']['__ids__'])
+    assert not any(n in prey_ids for n in neighbours)
+
+def test_network_invalid_agent_type_raises(sample_soa):
+    config = {'mode': 'network', 'agent_types': ['predator'],
+              'graph': {'type': 'erdos_renyi', 'n': 10, 'p': 0.5, 'seed': 1}}
+    with pytest.raises(ValueError) as e:
+        NetworkTopology.from_config(config, sample_soa)
+    assert 'agent_types contains unknown type(s): ' in str(e.value)

--- a/simulator-project-simulator/tests/test_random_sample.py
+++ b/simulator-project-simulator/tests/test_random_sample.py
@@ -1,0 +1,132 @@
+import pytest
+import random
+
+from topology.random_sample import RandomSampleTopology
+
+def test_set_random_sample_topology_from_k_config_success(sample_soa):
+    config = {'mode': 'random_sample', 'k': 5, 'seed': 42}
+    topology = RandomSampleTopology.from_config(config, sample_soa)
+    assert topology.k == 5
+    assert topology.proportion is None
+
+def test_set_random_sample_topology_from_prob_config_success(sample_soa):
+    config = {'mode': 'random_sample', 'proportion': 0.5, 'seed': 42}
+    topology = RandomSampleTopology.from_config(config, sample_soa)
+    assert topology.proportion == 0.5
+    assert topology.k is None
+
+def test_set_random_sample_topology_from_k_and_prob_config_throws_value_error(sample_soa):
+    config = {'mode': 'random_sample', 'k': 5, 'proportion': 0.5}
+    with pytest.raises(ValueError):
+        RandomSampleTopology.from_config(config, sample_soa)
+
+def test_random_sample_rejects_invalid_proportion(sample_soa):
+    config = {'mode': 'random_sample', 'proportion': 1.01, 'seed': 4}
+    with pytest.raises(ValueError) as e:
+        RandomSampleTopology.from_config(config, sample_soa)
+    assert "proportion must be in (0.0, 1.0], got " in str(e.value)
+
+def test_random_sample_rejects_invalid_k(sample_soa):
+    config = {'mode': 'random_sample', 'k': 0, 'seed': 4}
+    with pytest.raises(ValueError) as e:
+        RandomSampleTopology.from_config(config, sample_soa)
+    assert "k must be >= 1, got" in str(e.value)
+
+def test_random_sample_fixed_k_returns_correct_count(sample_soa):
+    config = {'mode': 'random_sample', 'k': 5, 'seed': 42}
+    topology = RandomSampleTopology.from_config(config, sample_soa)
+
+    # Pick a real agent ID from the population
+    agent_ids = list(sample_soa['person']['__ids__'])
+    target_agent_id = str(agent_ids[random.randint(0, len(agent_ids) - 1)])
+
+    result = topology.get_neighbours(target_agent_id, sample_soa)
+
+    assert len(result) == config['k']
+
+def test_random_sample_fixed_k_excludes_self(sample_soa):
+    config = {'mode': 'random_sample', 'k': 5, 'seed': 42}
+    topology = RandomSampleTopology.from_config(config, sample_soa)
+
+    # Pick a real agent ID from the population
+    agent_ids = list(sample_soa['person']['__ids__'])
+    target_agent_id = str(agent_ids[random.randint(0, len(agent_ids) - 1)])
+
+    result = topology.get_neighbours(target_agent_id, sample_soa)
+
+    assert target_agent_id not in result
+
+def test_random_sample_fixed_k_capped_at_pool_size(sample_soa):
+    pool_size = len(sample_soa['person']['__ids__'])
+    config = {'mode': 'random_sample', 'k': random.randint(pool_size, 100), 'seed': 42}
+    topology = RandomSampleTopology.from_config(config, sample_soa)
+
+    # Pick a real agent ID from the population
+    agent_ids = list(sample_soa['person']['__ids__'])
+    target_agent_id = str(agent_ids[random.randint(0, len(agent_ids) - 1)])
+
+    result = topology.get_neighbours(target_agent_id, sample_soa)
+
+    assert len(result) == pool_size - 1
+
+def test_random_sample_same_seed_produces_same_result(sample_soa):
+    pool_size = len(sample_soa['person']['__ids__'])
+    k = random.randint(1, pool_size - 1)
+
+    config_01 = {'mode': 'random_sample', 'k': k, 'seed': 42}
+    topology_01 = RandomSampleTopology.from_config(config_01, sample_soa)
+
+    config_02 = {'mode': 'random_sample', 'k': k, 'seed': 42}
+    topology_02 = RandomSampleTopology.from_config(config_02, sample_soa)
+
+    # Pick a real agent ID from the population
+    agent_ids = list(sample_soa['person']['__ids__'])
+    target_agent_id = str(agent_ids[random.randint(0, len(agent_ids) - 1)])
+
+    result_01 = topology_01.get_neighbours(target_agent_id, sample_soa)
+    result_02 = topology_02.get_neighbours(target_agent_id, sample_soa)
+
+    assert result_01 == result_02
+
+def test_random_sample_different_seed_produces_different_result(sample_soa):
+    pool_size = len(sample_soa['person']['__ids__'])
+    agent_ids = list(sample_soa['person']['__ids__'])
+    target_agent_id = str(agent_ids[0])
+
+    results = []
+    for seed in range(5):
+        config = {'mode': 'random_sample', 'k': pool_size - 1, 'seed': seed}
+        topology = RandomSampleTopology.from_config(config, sample_soa)
+        results.append(tuple(topology.get_neighbours(target_agent_id, sample_soa)))
+
+    assert len(set(results)) > 1  # at least some seeds produce different results
+
+def test_random_sample_filters_by_agent_types(mixed_type_soa):
+    config = {'mode': 'random_sample', 'k': 3, 'agent_types': ['predator']}
+    topology = RandomSampleTopology.from_config(config, mixed_type_soa)
+
+    predator_ids = list(mixed_type_soa['predator']['__ids__'])
+    target_agent_id = str(predator_ids[0])
+
+    result = topology.get_neighbours(target_agent_id, mixed_type_soa)
+
+    prey_ids = set(str(id_) for id_ in mixed_type_soa['prey']['__ids__'])
+    assert not any(n in prey_ids for n in result)
+
+def test_random_sample_invalid_agent_type_raises(sample_soa):
+    config = {'mode': 'random_sample', 'k': 5, 'agent_types': ['predator']}
+    with pytest.raises(ValueError) as e:
+        RandomSampleTopology.from_config(config, sample_soa)
+
+def test_random_sample_empty_pool_returns_empty(sample_soa_single_agent):
+    pool_size = len(sample_soa_single_agent['person']['__ids__'])
+    config = {'mode': 'random_sample', 'k': random.randint(pool_size, 100), 'seed': 1}
+    topology = RandomSampleTopology.from_config(config, sample_soa_single_agent)
+
+    # Pick a real agent ID from the population
+    agent_ids = list(sample_soa_single_agent['person']['__ids__'])
+    target_agent_id = str(agent_ids[random.randint(0, len(agent_ids) - 1)])
+
+    result = topology.get_neighbours(target_agent_id, sample_soa_single_agent)
+
+    assert len(result) == 0

--- a/simulator-project-simulator/tests/test_topology.py
+++ b/simulator-project-simulator/tests/test_topology.py
@@ -1,0 +1,34 @@
+import pytest
+
+from topology.topology import TopologyProtocol, build_topologies
+from topology.all_pairs import AllPairsTopology
+from topology.random_sample import RandomSampleTopology
+from topology.network import NetworkTopology
+
+
+def test_generate_topology_protocol_success(sample_soa):
+    config = {'topologies': {'sample_network_01': {'mode': 'random_sample', 'k': 2}, 'sample_network_02': {'mode': 'all_pairs', 'agent_types': ['person']}, 'sample_network_03': {'mode': 'network', 'agent_types': ['person'], 'graph': {'type': 'erdos_renyi', 'n': 10, 'p': 0.05, 'seed': 1}}}}
+
+    result = build_topologies(config, sample_soa)
+
+    assert 'sample_network_01' in result
+    assert 'sample_network_02' in result
+    assert 'sample_network_03' in result
+    assert isinstance(result['sample_network_01'], TopologyProtocol)
+    assert isinstance(result['sample_network_01'], RandomSampleTopology)
+    assert isinstance(result['sample_network_02'], TopologyProtocol)
+    assert isinstance(result['sample_network_02'], AllPairsTopology)
+    assert isinstance(result['sample_network_03'], TopologyProtocol)
+    assert isinstance(result['sample_network_03'], NetworkTopology)
+
+def test_build_topologies_missing_section_raises(sample_soa):
+    config = {}
+    with pytest.raises(ValueError, match="must contain a 'topologies' section"):
+        build_topologies(config, sample_soa)
+
+def test_unknown_topology_raises_value_error(sample_soa):
+    config = {'topologies': {'sample_network_01': {'mode': 'unknown'}}}
+
+    with pytest.raises(ValueError, match='unknown mode') as e:
+        build_topologies(config, sample_soa)
+    assert "Expected one of: all_pairs, random_sample, network." in str(e.value)

--- a/simulator-project-simulator/topology/all_pairs.py
+++ b/simulator-project-simulator/topology/all_pairs.py
@@ -1,0 +1,103 @@
+"""
+all_pairs.py — All-pairs topology implementation.
+
+Returns the full directed neighbour set for each agent — every other agent
+in the population is a neighbour. This produces N-1 neighbours per agent
+(N² - N total pairs across the population).
+
+Self-interaction is excluded by default. This means agent A will never
+appear in its own neighbour list. This is not configurable in the current
+implementation — enabling self-interaction is an unusual case and deferred
+to a later ticket if needed.
+
+Cross-type interactions are included by default — get_neighbours for a
+predator returns both predator and prey IDs. To restrict to specific
+types, set agent_types in the topology config.
+
+Unordered pairs optimisation (N(N-1)/2 instead of N²) is deferred to a
+later optimisation ticket — only relevant for symmetric interactions like
+physical collision where (A,B) and (B,A) are the same interaction.
+
+Config shape:
+    topologies:
+      contact:
+        mode: all_pairs
+        agent_types: null           # optional, null means all types
+        # or
+        agent_types:
+          - predator
+          - prey
+"""
+
+from __future__ import annotations
+
+from runner.soa import SoAPopulation, ID_KEY
+
+
+class AllPairsTopology:
+    """Topology implementation that returns all other agents as neighbours.
+
+    Satisfies TopologyProtocol structurally — no inheritance needed.
+    """
+
+    def __init__(
+        self,
+        allow_self_interaction: bool = False,
+        agent_types: list[str] | None = None,
+    ):
+        """
+        Args:
+            allow_self_interaction: if True, agent appears in its own
+                neighbour list. Default False.
+            agent_types: if set, only agents of these types are returned
+                as neighbours. If None, all types are included.
+        """
+        self.allow_self_interaction = allow_self_interaction
+        self.agent_types = agent_types
+
+    @classmethod
+    def from_config(cls, config: dict, soa: SoAPopulation) -> "AllPairsTopology":
+        """Construct from a topology config section.
+
+        Args:
+            config: the config dict for this topology, e.g.
+                {
+                    "mode": "all_pairs",
+                    "agent_types": ["predator", "prey"]
+                }
+            soa: the current SoAPopulation (unused by AllPairsTopology,
+                 accepted for Protocol consistency)
+        """
+        return cls(
+            allow_self_interaction=config.get("allow_self_interaction", False),
+            agent_types=config.get("agent_types", None),
+        )
+
+    def get_neighbours(self, agent_id: str, soa: SoAPopulation) -> list[str]:
+        """Return all agent IDs in the population except self (by default).
+
+        Iterates over all agent types in the SoA, collecting IDs from
+        each type's __ids__ array. Filters by agent_types if specified.
+
+        Args:
+            agent_id: the ID of the focal agent
+            soa: the current SoAPopulation
+
+        Returns:
+            list of neighbour agent ID strings
+        """
+        neighbours: list[str] = []
+
+        for type_name, arrays in soa.items():
+            # Filter by agent_types if specified
+            if self.agent_types is not None and type_name not in self.agent_types:
+                continue
+
+            for id_ in arrays[ID_KEY]:
+                id_str = str(id_)
+                # Exclude self unless allow_self_interaction is True
+                if not self.allow_self_interaction and id_str == agent_id:
+                    continue
+                neighbours.append(id_str)
+
+        return neighbours

--- a/simulator-project-simulator/topology/all_pairs.py
+++ b/simulator-project-simulator/topology/all_pairs.py
@@ -32,6 +32,7 @@ Config shape:
 from __future__ import annotations
 
 from runner.soa import SoAPopulation, ID_KEY
+from topology.topology import validate_agent_types
 
 
 class AllPairsTopology:
@@ -65,12 +66,18 @@ class AllPairsTopology:
                     "mode": "all_pairs",
                     "agent_types": ["predator", "prey"]
                 }
-            soa: the current SoAPopulation (unused by AllPairsTopology,
-                 accepted for Protocol consistency)
+            soa: the current SoAPopulation, used to validate agent_types
+                 refers to real agent types present in the population
+
+        Raises:
+            ValueError: if agent_types contains a type not present in soa
         """
+        agent_types = config.get("agent_types", None)
+        validate_agent_types(agent_types, soa)
+
         return cls(
             allow_self_interaction=config.get("allow_self_interaction", False),
-            agent_types=config.get("agent_types", None),
+            agent_types=agent_types,
         )
 
     def get_neighbours(self, agent_id: str, soa: SoAPopulation) -> list[str]:

--- a/simulator-project-simulator/topology/graph_builder.py
+++ b/simulator-project-simulator/topology/graph_builder.py
@@ -1,0 +1,271 @@
+"""
+graph_builder.py — NetworkX graph construction and loading.
+
+Scope:
+  - Build graphs from config (erdos_renyi, barabasi_albert, watts_strogatz)
+  - Load graphs from file (GraphML, GML, edgelist, adjacency list)
+  - Validate that graph node IDs match SoA agent IDs
+  - All graphs are undirected (networkx.Graph)
+
+Node labelling:
+  All graphs use UUID strings as node labels, matching agent IDs in the
+  SoAPopulation. Bring-your-own graphs must use UUID node labels — integer
+  node IDs will fail validation. This ensures get_neighbours(agent_id)
+  maps directly to graph.neighbors(agent_id) without any position-based
+  translation, which would break when agents are added or removed.
+
+Supported graph types (generated):
+  - erdos_renyi: random graph with n nodes and edge probability p
+  - barabasi_albert: scale-free graph with n nodes, m edges per new node
+  - watts_strogatz: small-world graph with n nodes, k nearest neighbours,
+    rewiring probability p
+
+Supported file formats (bring-your-own):
+  - .graphml
+  - .gml
+  - .edgelist
+  - .adjlist
+
+Config shape (generated):
+    graph:
+      type: erdos_renyi
+      n: 1000
+      p: 0.05
+      seed: 42        # optional
+
+    graph:
+      type: barabasi_albert
+      n: 1000
+      m: 3
+      seed: 42
+
+    graph:
+      type: watts_strogatz
+      n: 1000
+      k: 4
+      p: 0.1
+      seed: 42
+
+Config shape (bring-your-own):
+    graph:
+      source: path/to/my_graph.graphml
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import networkx as nx
+
+from runner.soa import SoAPopulation, ID_KEY
+
+
+# ---------------------------------------------------------------------------
+# Supported formats
+# ---------------------------------------------------------------------------
+
+_FILE_READERS = {
+    ".graphml": nx.read_graphml,
+    ".gml":     nx.read_gml,
+    ".edgelist": nx.read_edgelist,
+    ".adjlist":  nx.read_adjlist,
+}
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def build_graph(config: dict, soa: SoAPopulation) -> nx.Graph:
+    """Build or load a NetworkX graph from config.
+
+    If config contains 'source', loads from file.
+    If config contains 'type', generates from parameters.
+
+    In both cases, validates that graph node IDs match SoA agent IDs.
+
+    Args:
+        config: the 'graph' section of the topology config
+        soa: the current SoAPopulation, used for agent ID validation
+             and node relabelling for generated graphs
+
+    Returns:
+        nx.Graph with UUID string node labels matching SoA agent IDs
+
+    Raises:
+        ValueError: unknown graph type, missing required params,
+                    or node IDs don't match SoA agent IDs
+        FileNotFoundError: source file does not exist
+        KeyError: unsupported file format
+    """
+    if "source" in config:
+        graph = _load_graph(config["source"])
+    elif "type" in config:
+        graph = _generate_graph(config, soa)
+    else:
+        raise ValueError("Graph config must contain either 'source' or 'type'.")
+
+    _validate_graph(graph, soa)
+    return graph
+
+
+# ---------------------------------------------------------------------------
+# Graph generation
+# ---------------------------------------------------------------------------
+
+def _generate_graph(config: dict, soa: SoAPopulation) -> nx.Graph:
+    """Generate a NetworkX graph from config parameters.
+
+    Nodes are labelled with UUID strings from the SoA agent IDs.
+    The graph is generated with integer nodes first (NetworkX default)
+    then relabelled to match agent IDs.
+
+    Args:
+        config: graph config section containing 'type' and parameters
+        soa: SoAPopulation providing agent IDs for node relabelling
+
+    Returns:
+        nx.Graph with UUID string node labels
+    """
+    graph_type = config.get("type")
+    seed = config.get("seed", None)
+
+    # Collect all agent IDs from SoA in order — used for node relabelling.
+    agent_ids = _collect_agent_ids(soa)
+
+    if graph_type == "erdos_renyi":
+        n = _require(config, "n", graph_type)
+        p = _require(config, "p", graph_type)
+        _check_node_count(n, agent_ids, graph_type)
+        graph = nx.erdos_renyi_graph(n=n, p=p, seed=seed)
+
+    elif graph_type == "barabasi_albert":
+        n = _require(config, "n", graph_type)
+        m = _require(config, "m", graph_type)
+        _check_node_count(n, agent_ids, graph_type)
+        graph = nx.barabasi_albert_graph(n=n, m=m, seed=seed)
+
+    elif graph_type == "watts_strogatz":
+        n = _require(config, "n", graph_type)
+        k = _require(config, "k", graph_type)
+        p = _require(config, "p", graph_type)
+        _check_node_count(n, agent_ids, graph_type)
+        graph = nx.watts_strogatz_graph(n=n, k=k, p=p, seed=seed)
+
+    else:
+        raise ValueError(
+            f"Unknown graph type '{graph_type}'. "
+            f"Expected one of: erdos_renyi, barabasi_albert, watts_strogatz."
+        )
+
+    # Relabel integer nodes (0, 1, 2...) to UUID strings.
+    mapping = {i: agent_ids[i] for i in range(len(agent_ids))}
+    return nx.relabel_nodes(graph, mapping)
+
+
+# ---------------------------------------------------------------------------
+# Graph loading
+# ---------------------------------------------------------------------------
+
+def _load_graph(source: str) -> nx.Graph:
+    """Load a graph from a file.
+
+    Node IDs in the file must be UUID strings matching SoA agent IDs.
+    Integer node IDs will fail validation downstream.
+
+    Args:
+        source: path to the graph file
+
+    Returns:
+        nx.Graph loaded from file
+
+    Raises:
+        FileNotFoundError: file does not exist
+        ValueError: unsupported file format
+    """
+    path = Path(source)
+
+    if not path.exists():
+        raise FileNotFoundError(f"Graph file not found: '{source}'")
+
+    suffix = path.suffix.lower()
+    if suffix not in _FILE_READERS:
+        raise ValueError(
+            f"Unsupported graph file format '{suffix}'. "
+            f"Expected one of: {', '.join(_FILE_READERS.keys())}"
+        )
+
+    return _FILE_READERS[suffix](source)
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+def _validate_graph(graph: nx.Graph, soa: SoAPopulation) -> None:
+    """Validate that graph node IDs match SoA agent IDs exactly.
+
+    Raises ValueError with a descriptive message if:
+      - Graph nodes are not a subset of SoA agent IDs
+      - SoA agent IDs are not a subset of graph nodes
+      (i.e. the sets must be equal)
+
+    Args:
+        graph: the NetworkX graph to validate
+        soa: the current SoAPopulation
+
+    Raises:
+        ValueError: if node IDs don't match SoA agent IDs
+    """
+    graph_nodes = set(str(n) for n in graph.nodes())
+    agent_ids = set(_collect_agent_ids(soa))
+
+    in_graph_not_soa = graph_nodes - agent_ids
+    in_soa_not_graph = agent_ids - graph_nodes
+
+    errors = []
+    if in_graph_not_soa:
+        errors.append(
+            f"Graph contains {len(in_graph_not_soa)} node(s) not in SoA: "
+            f"{sorted(in_graph_not_soa)[:5]}{'...' if len(in_graph_not_soa) > 5 else ''}"
+        )
+    if in_soa_not_graph:
+        errors.append(
+            f"SoA contains {len(in_soa_not_graph)} agent(s) not in graph: "
+            f"{sorted(in_soa_not_graph)[:5]}{'...' if len(in_soa_not_graph) > 5 else ''}"
+        )
+    if errors:
+        raise ValueError(
+            "Graph node IDs do not match SoA agent IDs:\n" + "\n".join(errors)
+        )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _collect_agent_ids(soa: SoAPopulation) -> list[str]:
+    """Collect all agent IDs from SoA in type-then-position order."""
+    ids = []
+    for arrays in soa.values():
+        ids.extend(str(id_) for id_ in arrays[ID_KEY])
+    return ids
+
+
+def _require(config: dict, key: str, graph_type: str) -> any:
+    """Get a required config parameter, raising a clear error if missing."""
+    if key not in config:
+        raise ValueError(
+            f"Graph type '{graph_type}' requires '{key}' in config."
+        )
+    return config[key]
+
+
+def _check_node_count(n: int, agent_ids: list[str], graph_type: str) -> None:
+    """Validate that n matches the number of agents in the SoA."""
+    if n != len(agent_ids):
+        raise ValueError(
+            f"Graph type '{graph_type}': n={n} does not match "
+            f"total agent count={len(agent_ids)} in SoA. "
+            f"These must be equal for node relabelling to work."
+        )

--- a/simulator-project-simulator/topology/network.py
+++ b/simulator-project-simulator/topology/network.py
@@ -1,0 +1,145 @@
+"""
+network.py — Network topology implementation using NetworkX.
+
+Returns graph-adjacent nodes as neighbours for each agent. The graph
+is built once at simulation start via graph_builder.py and held in
+memory for the duration of the simulation.
+
+Node IDs in the graph are UUID strings matching agent IDs in the
+SoAPopulation. get_neighbours(agent_id, soa) maps directly to
+graph.neighbors(agent_id) — no position-based translation needed.
+
+Self-interaction is excluded — NetworkX simple graphs do not have
+self-loops by default, so an agent will never appear in its own
+neighbour list unless a self-loop was explicitly added to the graph.
+
+Cross-type interactions are included by default. Set agent_types in
+config to restrict the neighbour pool to specific agent types.
+
+The graph is undirected (nx.Graph). Directed graph support is deferred
+to a later ticket.
+
+Config shape:
+    topologies:
+      contact:
+        mode: network
+        agent_types: null       # optional, null means all types
+        graph:
+          type: erdos_renyi
+          n: 1000
+          p: 0.05
+          seed: 42
+
+      # or bring-your-own
+      contact:
+        mode: network
+        graph:
+          source: path/to/my_graph.graphml
+"""
+
+from __future__ import annotations
+
+import networkx as nx
+
+from runner.soa import SoAPopulation, ID_KEY
+from topology.graph_builder import build_graph
+
+
+class NetworkTopology:
+    """Topology implementation that returns graph-adjacent agents as neighbours.
+
+    Satisfies TopologyProtocol structurally — no inheritance needed.
+
+    The graph is built once at construction time and reused each step.
+    For dynamic rewiring (agents forming/dropping connections mid-simulation),
+    see S-03b.
+    """
+
+    def __init__(
+        self,
+        graph: nx.Graph,
+        agent_types: list[str] | None = None,
+    ):
+        """
+        Args:
+            graph: a NetworkX Graph with UUID string node labels matching
+                   agent IDs in the SoAPopulation
+            agent_types: if set, only neighbours of these types are returned.
+                         If None, all types are included.
+        """
+        self.graph = graph
+        self.agent_types = agent_types
+
+    @classmethod
+    def from_config(cls, config: dict, soa: SoAPopulation) -> "NetworkTopology":
+        """Construct from a topology config section.
+
+        Builds or loads the graph via graph_builder, then constructs
+        the NetworkTopology instance.
+
+        Args:
+            config: the config dict for this topology, e.g.
+                {
+                    "mode": "network",
+                    "agent_types": ["person"],
+                    "graph": {
+                        "type": "erdos_renyi",
+                        "n": 1000,
+                        "p": 0.05,
+                        "seed": 42
+                    }
+                }
+            soa: the current SoAPopulation, needed by graph_builder for
+                 node relabelling and validation
+
+        Raises:
+            ValueError: if 'graph' section is missing from config
+        """
+        if "graph" not in config:
+            raise ValueError(
+                "Network topology config must contain a 'graph' section."
+            )
+
+        graph = build_graph(config["graph"], soa)
+
+        return cls(
+            graph=graph,
+            agent_types=config.get("agent_types", None),
+        )
+
+    def get_neighbours(self, agent_id: str, soa: SoAPopulation) -> list[str]:
+        """Return graph-adjacent agent IDs for the given agent.
+
+        Looks up neighbours directly from the NetworkX graph using
+        agent_id as the node label. Filters by agent_types if specified.
+
+        Args:
+            agent_id: the ID of the focal agent
+            soa: the current SoAPopulation (used for agent_types filtering)
+
+        Returns:
+            list of neighbour agent ID strings. Empty list if the agent
+            has no edges in the graph or is not in the graph.
+        """
+        if agent_id not in self.graph:
+            return []
+
+        # Get graph-adjacent node IDs.
+        raw_neighbours = [str(n) for n in self.graph.neighbors(agent_id)]
+
+        if self.agent_types is None:
+            return raw_neighbours
+
+        # Filter by agent_types — build a set of IDs belonging to
+        # allowed types from the SoA for O(1) membership check.
+        allowed_ids = self._get_allowed_ids(soa)
+        return [n for n in raw_neighbours if n in allowed_ids]
+
+    def _get_allowed_ids(self, soa: SoAPopulation) -> set[str]:
+        """Build a set of agent IDs belonging to allowed agent_types."""
+        allowed: set[str] = set()
+        for type_name, arrays in soa.items():
+            if self.agent_types is not None and type_name not in self.agent_types:
+                continue
+            allowed.update(str(id_) for id_ in arrays[ID_KEY])
+        return allowed

--- a/simulator-project-simulator/topology/network.py
+++ b/simulator-project-simulator/topology/network.py
@@ -43,6 +43,7 @@ import networkx as nx
 
 from runner.soa import SoAPopulation, ID_KEY
 from topology.graph_builder import build_graph
+from topology.topology import validate_agent_types
 
 
 class NetworkTopology:
@@ -93,18 +94,22 @@ class NetworkTopology:
                  node relabelling and validation
 
         Raises:
-            ValueError: if 'graph' section is missing from config
+            ValueError: if 'graph' section is missing from config, or if
+                agent_types contains a type not present in soa
         """
         if "graph" not in config:
             raise ValueError(
                 "Network topology config must contain a 'graph' section."
             )
 
+        agent_types = config.get("agent_types", None)
+        validate_agent_types(agent_types, soa)
+
         graph = build_graph(config["graph"], soa)
 
         return cls(
             graph=graph,
-            agent_types=config.get("agent_types", None),
+            agent_types=agent_types,
         )
 
     def get_neighbours(self, agent_id: str, soa: SoAPopulation) -> list[str]:

--- a/simulator-project-simulator/topology/random_sample.py
+++ b/simulator-project-simulator/topology/random_sample.py
@@ -1,0 +1,154 @@
+"""
+random_sample.py — Random sample topology implementation.
+
+Returns a random subset of the population as neighbours for each agent.
+Supports two sampling modes:
+  - Fixed (k): always return exactly k neighbours
+  - Proportional: return k% of the eligible population
+
+Sampling is with replacement, so duplicates are possible when k is large
+relative to population size. If k exceeds the eligible pool size in fixed
+mode, all eligible agents are returned (capped, no error raised).
+
+Self-interaction is excluded — agent A will never appear in its own
+neighbour list. This is not configurable in the current implementation;
+see S-03b for future extensions.
+
+Cross-type interactions are included by default. Set agent_types in config
+to restrict the neighbour pool to specific agent types.
+
+Each topology instance can have its own random seed for reproducibility.
+Global seeding (S-11) can override this later — the seed here is
+topology-local only.
+
+Config shape:
+    topologies:
+      disease_spread:
+        mode: random_sample
+        k: 5                        # fixed sample size
+        seed: 42                    # optional
+        agent_types: null           # null means all types
+
+      social_influence:
+        mode: random_sample
+        proportion: 0.1             # 10% of eligible population
+        seed: 123
+        agent_types:
+          - person
+"""
+
+from __future__ import annotations
+
+import math
+import numpy as np
+
+from runner.soa import SoAPopulation, ID_KEY
+
+
+class RandomSampleTopology:
+    """Topology implementation that returns a random subset of agents
+    as neighbours.
+
+    Satisfies TopologyProtocol structurally — no inheritance needed.
+    """
+
+    def __init__(
+        self,
+        k: int | None = None,
+        proportion: float | None = None,
+        seed: int | None = None,
+        agent_types: list[str] | None = None,
+    ):
+        """
+        Args:
+            k: fixed number of neighbours to sample. Mutually exclusive
+                with proportion.
+            proportion: fraction of eligible population to sample (0.0–1.0).
+                Mutually exclusive with k.
+            seed: random seed for this topology instance. Optional.
+            agent_types: if set, only agents of these types are eligible
+                as neighbours. If None, all types are included.
+
+        Raises:
+            ValueError: if neither or both of k and proportion are set,
+                or if proportion is outside (0.0, 1.0].
+        """
+        if k is None and proportion is None:
+            raise ValueError("RandomSampleTopology requires either 'k' or 'proportion'.")
+        if k is not None and proportion is not None:
+            raise ValueError("RandomSampleTopology requires either 'k' or 'proportion', not both.")
+        if proportion is not None and not (0.0 < proportion <= 1.0):
+            raise ValueError(f"proportion must be in (0.0, 1.0], got {proportion}.")
+        if k is not None and k < 1:
+            raise ValueError(f"k must be >= 1, got {k}.")
+
+        self.k = k
+        self.proportion = proportion
+        self.agent_types = agent_types
+        self.rng = np.random.default_rng(seed)
+
+    @classmethod
+    def from_config(cls, config: dict) -> "RandomSampleTopology":
+        """Construct from a topology config section.
+
+        Args:
+            config: the config dict for this topology, e.g.
+                {
+                    "mode": "random_sample",
+                    "k": 5,
+                    "seed": 42,
+                    "agent_types": ["person"]
+                }
+        """
+        return cls(
+            k=config.get("k", None),
+            proportion=config.get("proportion", None),
+            seed=config.get("seed", None),
+            agent_types=config.get("agent_types", None),
+        )
+
+    def _get_eligible_pool(self, agent_id: str, soa: SoAPopulation) -> list[str]:
+        """Build the eligible neighbour pool, excluding self and
+        filtering by agent_types if specified."""
+        pool: list[str] = []
+
+        for type_name, arrays in soa.items():
+            if self.agent_types is not None and type_name not in self.agent_types:
+                continue
+            for id_ in arrays[ID_KEY]:
+                id_str = str(id_)
+                if id_str != agent_id:  # always exclude self
+                    pool.append(id_str)
+
+        return pool
+
+    def _sample_size(self, pool_size: int) -> int:
+        """Determine how many neighbours to sample given the pool size."""
+        if self.k is not None:
+            # Fixed mode — cap at pool size to avoid errors
+            return min(self.k, pool_size)
+        else:
+            # Proportional mode — at least 1 neighbour
+            return max(1, math.ceil(self.proportion * pool_size))
+
+    def get_neighbours(self, agent_id: str, soa: SoAPopulation) -> list[str]:
+        """Return a random sample of agent IDs from the eligible pool.
+
+        Sampling is with replacement. Self is always excluded.
+
+        Args:
+            agent_id: the ID of the focal agent
+            soa: the current SoAPopulation
+
+        Returns:
+            list of neighbour agent ID strings, length determined by
+            k or proportion. Empty list if no eligible neighbours exist.
+        """
+        pool = self._get_eligible_pool(agent_id, soa)
+
+        if not pool:
+            return []
+
+        sample_size = self._sample_size(len(pool))
+        indices = self.rng.integers(0, len(pool), size=sample_size)
+        return [pool[i] for i in indices]

--- a/simulator-project-simulator/topology/random_sample.py
+++ b/simulator-project-simulator/topology/random_sample.py
@@ -43,6 +43,7 @@ import math
 import numpy as np
 
 from runner.soa import SoAPopulation, ID_KEY
+from topology.topology import validate_agent_types
 
 
 class RandomSampleTopology:
@@ -88,7 +89,7 @@ class RandomSampleTopology:
         self.rng = np.random.default_rng(seed)
 
     @classmethod
-    def from_config(cls, config: dict) -> "RandomSampleTopology":
+    def from_config(cls, config: dict, soa: SoAPopulation) -> "RandomSampleTopology":
         """Construct from a topology config section.
 
         Args:
@@ -100,11 +101,13 @@ class RandomSampleTopology:
                     "agent_types": ["person"]
                 }
         """
+        agent_types = config.get("agent_types", None)
+        validate_agent_types(agent_types, soa)
         return cls(
             k=config.get("k", None),
             proportion=config.get("proportion", None),
             seed=config.get("seed", None),
-            agent_types=config.get("agent_types", None),
+            agent_types=agent_types,
         )
 
     def _get_eligible_pool(self, agent_id: str, soa: SoAPopulation) -> list[str]:

--- a/simulator-project-simulator/topology/topology.py
+++ b/simulator-project-simulator/topology/topology.py
@@ -1,0 +1,163 @@
+"""
+topology.py — Protocol definition and factory for multiplex topologies.
+
+Scope:
+  - TopologyProtocol: structural interface all topology implementations satisfy
+  - build_topologies: factory that reads config and returns dict of named topologies
+
+Not in scope:
+  - Individual topology implementations (all_pairs.py, random_sample.py, network.py)
+  - Graph construction (graph_builder.py)
+  - Dynamic rewiring (S-03b)
+
+Multiplex topology:
+  Multiple named topologies can be active simultaneously. For example,
+  a disease model might have a contact network for infection spread and
+  a random sample layer for opinion influence:
+
+    topologies:
+      contact:
+        mode: network
+        graph:
+          type: erdos_renyi
+          n: 1000
+          p: 0.05
+      social:
+        mode: random_sample
+        k: 5
+
+  build_topologies returns:
+    {
+      "contact": NetworkTopology(...),
+      "social": RandomSampleTopology(k=5),
+    }
+
+  Behaviour modules reference topologies by name:
+    infection_neighbours = topologies["contact"].get_neighbours(agent_id, soa)
+    opinion_neighbours = topologies["social"].get_neighbours(agent_id, soa)
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from runner.soa import SoAPopulation
+
+
+# ---------------------------------------------------------------------------
+# Protocol
+# ---------------------------------------------------------------------------
+
+@runtime_checkable
+class TopologyProtocol(Protocol):
+    """Structural interface for all topology implementations.
+
+    Any class implementing get_neighbours and from_config satisfies
+    this Protocol — no inheritance required.
+
+    @runtime_checkable allows isinstance() checks at runtime, useful
+    for factory validation and testing.
+    """
+
+    def get_neighbours(self, agent_id: str, soa: SoAPopulation) -> list[str]:
+        """Return list of agent ID strings that are neighbours of agent_id.
+
+        Called once per agent per simulation step. Behaviour modules
+        consume this list without knowing which topology is active.
+
+        Self-interaction is excluded by default across all implementations.
+
+        Args:
+            agent_id: the ID of the focal agent
+            soa: the current SoAPopulation
+
+        Returns:
+            list of neighbour agent ID strings
+        """
+        ...
+
+    @classmethod
+    def from_config(cls, config: dict, soa: SoAPopulation) -> "TopologyProtocol":
+        """Construct this topology from a config dict section.
+
+        Each implementation parses its own relevant keys from config.
+        soa is required by NetworkTopology for graph node relabelling
+        and validation; other implementations may ignore it.
+
+        Args:
+            config: the config section for this topology
+            soa: the current SoAPopulation
+        """
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Factory
+# ---------------------------------------------------------------------------
+
+def build_topologies(config: dict, soa: SoAPopulation) -> dict[str, TopologyProtocol]:
+    """Factory — reads the 'topologies' section of the simulation config
+    and returns a dict of named topology instances.
+
+    Args:
+        config: the full simulation config dict containing a 'topologies' section
+        soa: the current SoAPopulation, passed through to topology constructors
+
+    Returns:
+        dict mapping topology name to topology instance, e.g.
+        {
+            "contact": NetworkTopology(...),
+            "social": RandomSampleTopology(k=5),
+        }
+
+    Raises:
+        ValueError: if 'topologies' section is missing or empty
+    """
+    topologies_config = config.get("topologies", {})
+    if not topologies_config:
+        raise ValueError(
+            "Config must contain a 'topologies' section with at least one topology."
+        )
+
+    return {
+        name: _build_single_topology(name, topology_config, soa)
+        for name, topology_config in topologies_config.items()
+    }
+
+
+def _build_single_topology(
+    name: str,
+    config: dict,
+    soa: SoAPopulation,
+) -> TopologyProtocol:
+    """Internal factory — constructs a single topology from its config section.
+
+    Lazy imports avoid circular dependencies between topology modules.
+
+    Args:
+        name: the topology name (used in error messages)
+        config: the config section for this topology
+        soa: the current SoAPopulation
+
+    Raises:
+        ValueError: if mode is unknown or missing
+    """
+    mode = config.get("mode")
+
+    if mode == "all_pairs":
+        from topology.all_pairs import AllPairsTopology
+        return AllPairsTopology.from_config(config, soa)
+
+    elif mode == "random_sample":
+        from topology.random_sample import RandomSampleTopology
+        return RandomSampleTopology.from_config(config, soa)
+
+    elif mode == "network":
+        from topology.network import NetworkTopology
+        return NetworkTopology.from_config(config, soa)
+
+    else:
+        raise ValueError(
+            f"Topology '{name}' has unknown mode '{mode}'. "
+            f"Expected one of: all_pairs, random_sample, network."
+        )

--- a/simulator-project-simulator/topology/topology.py
+++ b/simulator-project-simulator/topology/topology.py
@@ -92,6 +92,40 @@ class TopologyProtocol(Protocol):
 
 
 # ---------------------------------------------------------------------------
+# Shared validation
+# ---------------------------------------------------------------------------
+
+def validate_agent_types(agent_types: list[str] | None, soa: SoAPopulation) -> None:
+    """Validate that every type name in agent_types exists in the SoAPopulation.
+
+    Shared across all_pairs, random_sample, and network topology implementations
+    to keep validation behaviour consistent. Raises loudly rather than silently
+    filtering to an empty neighbour list, which would otherwise be very hard
+    to debug (e.g. a typo'd agent type name silently produces an empty
+    simulation with no error).
+
+    Args:
+        agent_types: list of agent type names to validate, or None (no-op)
+        soa: the current SoAPopulation, used as the source of truth for
+             which agent types actually exist
+
+    Raises:
+        ValueError: if any name in agent_types is not a known agent type in soa
+    """
+    if agent_types is None:
+        return
+
+    known_types = set(soa.keys())
+    unknown = [t for t in agent_types if t not in known_types]
+
+    if unknown:
+        raise ValueError(
+            f"agent_types contains unknown type(s): {unknown}. "
+            f"Known agent types in population: {sorted(known_types)}"
+        )
+
+
+# ---------------------------------------------------------------------------
 # Factory
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
# Interaction Topology

Implements configurable interaction topologies for agent-to-agent neighbour resolution, with support for multiplex (multiple simultaneous named) topologies.

## What's included

- **`topology.py`** — `TopologyProtocol` (structural interface via `typing.Protocol`), `build_topologies(config, soa)` factory returning a `dict[str, TopologyProtocol]` for multiplex support, and a shared `validate_agent_types` helper.
- **`all_pairs.py`** — `AllPairsTopology`, full directed neighbour set (N-1 per agent), self excluded by default, optional `agent_types` filter.
- **`random_sample.py`** — `RandomSampleTopology`, fixed (`k`) or proportional sampling with replacement, seeded per instance, capped at pool size.
- **`network.py`** — `NetworkTopology`, graph-adjacent neighbours via NetworkX, agent IDs used directly as node labels (no position mapping).
- **`graph_builder.py`** — builds graphs from config (`erdos_renyi`, `barabasi_albert`, `watts_strogatz`) or loads from file (`.graphml`, `.gml`, `.edgelist`, `.adjlist`); validates node IDs match SoA agent IDs.

## Design decisions

- Cross-type interaction is the default; `agent_types` restricts the pool when needed.
- All-pairs is directed (N² pairs) — unordered-pair optimisation deferred to a future ticket.
- Graphs use UUID node labels to stay robust to agent addition/removal.
- Multiplex topologies supported from the start — different named topologies can drive different processes in the same simulation (e.g. contact network for infection, random sample for opinion influence).

## `validate_agent_types` fix

All three implementations initially accepted an `agent_types` config value referencing a type not present in the population, silently returning an empty neighbour list rather than raising. Added a shared `validate_agent_types(agent_types, soa)` helper in `topology.py`, called from each implementation's `from_config`, to raise a clear `ValueError` naming the unknown type instead of failing silently downstream.

## Explicitly out of scope

- **S-03b (placeholder):** dynamic graph rewiring — blocked on this ticket and S-05 (Behaviour).
- Spatial proximity — lives in Environment (S-04).
- Directed graph support for network mode.

## Tests

Full coverage across `test_topology.py`, `test_all_pairs.py`, `test_random_sample.py`, `test_graph_builder.py`, `test_network.py` — construction, neighbour correctness, self-exclusion, cross-type filtering, edge cases (isolated nodes, single-agent populations, mismatched node IDs), and the `validate_agent_types` failure path across all three modes.